### PR TITLE
Add check for already parsed requests

### DIFF
--- a/src/BodyParser.js
+++ b/src/BodyParser.js
@@ -57,7 +57,9 @@ var xmlOptions = {
 };
 
 exports.xmlBodyParser = function(req, res, next) {
-  if (req.is("application/xml") || req.is("text/xml")) {
+  var isNotParsed = req._body !== true;
+  var isXML = req.is("application/xml") || req.is("text/xml")    
+  if (isNotParsed && isXML) {
     var bodyStr = '';
     req.on("data", function(chunk) {
       bodyStr += chunk.toString();
@@ -65,6 +67,8 @@ exports.xmlBodyParser = function(req, res, next) {
     req.on("end", function(chunk) {
       try {
         req.body = xmlParser.toJson(bodyStr, xmlOptions);
+        // mark as parsed
+        req._body = true;
         next();
       } catch (err) {
         res.status(400).send({ status: "FAILURE", responseCode: 'XML_PARSING_ERROR', responseMessage: 'Failed while parsing XML Request' });


### PR DESCRIPTION
ExpressJS' body parser sets the `_body` flag on a Request to `true`
when it parses the request body as a guard against subsequent parsing
middlewares trying to re-parse the body.

Added a check for `_body` flag to the `xmlBodyParser` for the same.
`xmlBodyParser` would also set this flag on successful parsing.